### PR TITLE
Update scripts code

### DIFF
--- a/src/smartcontract_for_it/capacity_0db.md
+++ b/src/smartcontract_for_it/capacity_0db.md
@@ -37,7 +37,7 @@ pool = zos.pools.get(12)
 # find some node that have 10 GiB of SSD disks
 nodes = zos.nodes_finder.nodes_search(sru=10)
 
-# pick a node available in the sed pool
+# pick a node available in the chosen pool
 node_id = None
 for node in nodes:
      if node.node_id in pool.node_ids:

--- a/src/smartcontract_for_it/capacity_0db.md
+++ b/src/smartcontract_for_it/capacity_0db.md
@@ -32,16 +32,25 @@ If you want to dive in more about 0-DB itself, head to the official repository: 
 ```python
 zos = j.sals.zos
 
+pool = zos.pools.get(12)
+
 # find some node that have 10 GiB of SSD disks
 nodes = zos.nodes_finder.nodes_search(sru=10)
 
+# pick a node available in the sed pool
+node_id = None
+for node in nodes:
+     if node.node_id in pool.node_ids:
+          node_id = node.node_id
+          break
+
 # create a 0-DB namespace workload of 10 GiB on a SSD disk.
 zdb = zos.zdb.create(
- node_id=nodes[0].node_id,
+ node_id=node_id,
  size=10,
  mode='seq',
  password='supersecret',
- pool_id=12,
+ pool_id=pool.pool_id,
  disk_type="SSD")
 
 # deploy the workload and retrieve its ID

--- a/src/smartcontract_for_it/capacity_container.md
+++ b/src/smartcontract_for_it/capacity_container.md
@@ -132,16 +132,15 @@ You can read them via redis using `SUBSCRIBE container-stats` for example.
 ## Example using sdk
 
 ``` python
-zos = j.sal.zos
+zos = j.sals.zos
 
 # add container reservation into the reservation
 container = zos.container.create(node_id='2fi9ZZiBGW4G9pnrN656bMfW6x55RSoHDeMrd9pgSA8T', # one of the node_id s that is part of the network
      network_name='<network_name>', # this assumes that this network is already provisioned on the node
      ip_address='172.24.1.10', # part of ip_range you reserved for your network xxx.xxx.1.10
-     Flist='https://hub.grid.tf/zaibon/zaibon-ubuntu-ssh-0.0.2.Flist', # Flist of the container you want to install,
+     flist='https://hub.grid.tf/zaibon/zaibon-ubuntu-ssh-0.0.2.flist', # Flist of the container you want to install,
      capacity_pool_id=12, # capacity pool ID
      disk_size=2048, # request a 2GiB of storage for the root disk for the container
-     disk_type='SSD' # use an SSD for the root disk of the container
      # interactive=True, # True only if corex_connect required, default false
      env={"KEY":"VAL"},
      entrypoint='/sbin/my_init') #

--- a/src/smartcontract_for_it/capacity_domain_delegation.md
+++ b/src/smartcontract_for_it/capacity_domain_delegation.md
@@ -18,7 +18,7 @@ zos = j.sals.zos
 
 # add domain delegation reservation into the reservation
 delegated = zos.gateway.delegate_domain(gateway_id='2fi9ZZiBGW4G9pnrN656bMfW6x55RSoHDeMrd9pgSA8T',
-          domain='TF Grid.zaibon.be',
+          domain='tfgrid.zaibon.be',
           pool_id=12)
 
 # deploy the workload

--- a/src/smartcontract_for_it/capacity_gw4to6.md
+++ b/src/smartcontract_for_it/capacity_gw4to6.md
@@ -15,8 +15,7 @@ The idea behind this primitive is to try to allow everyone to access the grid, w
 ``` python
 zos = j.sals.zos
 
-workload = zos.gateway.gateway_4to6(reservation=r,
-       node_id='2fi9ZZiBGW4G9pnrN656bMfW6x55RSoHDeMrd9pgSA8T',
+workload = zos.gateway.gateway_4to6(gateway_id='2fi9ZZiBGW4G9pnrN656bMfW6x55RSoHDeMrd9pgSA8T',
        public_key="Zzfi3yTPtHMPF0JtjQ3wKpmeEch7G86X1NC5Qwvx0Sc=",
        pool_id=12)
 

--- a/src/smartcontract_for_it/capacity_kubernetes.md
+++ b/src/smartcontract_for_it/capacity_kubernetes.md
@@ -63,8 +63,8 @@ worker = zos.kubernetes.add_worker(
  pool_id=12)
 
 # deploy both master and worker
-zos.workloads.deploy(master)
-zos.workloads.deploy(worker)
+master_id = zos.workloads.deploy(master)
+worker_id = zos.workloads.deploy(worker)
 
 time.sleep(120)
 # inspect the result of the reservation provisioning

--- a/src/smartcontract_for_it/capacity_network.md
+++ b/src/smartcontract_for_it/capacity_network.md
@@ -78,7 +78,7 @@ for i, node in enumerate(nodes):
        pool_id=12)
 
 # find a node that is public and has a ipv4 public IP
-node = list(filter(zos.nodes_finder.filter_public_ip4, nodes))
+node = list(filter(zos.nodes_finder.filter_public_ip4, nodes))[0]
 # create an 'external access' to the network for user laptop access using the public node as entrypoint
 # we store the result of this command cause this is the configuration the user has to use to connect to
 # the network from his laptop


### PR DESCRIPTION
## Changes
ZDB:
- Pick a node available in the used pool.

Container:
- typo: sal -> sals.
- Disk type no longer accepted by the zos sal. It's always SSD.
- flist argument shouldn't be capitalized.

Domain delegation:
- Domain name contains spaces.

gw4to6:
- `reservation=r,` deleted.

k8s:
- master_id is not defined.

network:
- Pick the first node from the list.

### Related issues

#267